### PR TITLE
Minor spelling/grammar nits and remove CLI scoping

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ These documents are formatted similarly to KEPs for the sake of uniformity.  Som
 
 ### Non-Goals
 
-- Graphical User Interfaces (GUIs) and CLI tools are out of scope
+- Graphical User Interfaces (GUIs) are out of scope
 - Protecting non Kubernetes workloads
 - Intra-pod restrictions (i.e., process restriction, kubectl exec)
 - Support for encryption of traffic

--- a/p0_user_stories.md
+++ b/p0_user_stories.md
@@ -6,13 +6,13 @@ Taken from https://docs.google.com/document/d/10t4q5XO1ED2PnK3ishn4y3G4Tma7uMYge
 
 ## tier-1
 
-- I want 2 apps in different namespaces to connect, but can't read (or write) the labels for those namespaces from my Kubernetes client.   I cannot select pods for this because I don't know all the labels and names of pod/services that i want to contact ahead of time. 
+- I want 2 apps in different namespaces to connect, but can't read (or write) the labels for those namespaces from my Kubernetes client.   I cannot select pods for this because I don't know all the labels and names of pod/services that I want to contact ahead of time. 
 
-- I want different pods (with potentially different labels) that fulfill a service to be able talk to each other, without talking to other services...  but don't know the labels on these services.
+- I want different pods (with potentially different labels) that fulfill a service to be able talk to each other, without talking to other services but I don't know the labels on these services.
 
-- I don't want to directly update my CIDR rules for a policy every time I add a new node or other group of IPs, which need to have policy's associated with them.
+- I don't want to directly update my CIDR rules for a policy every time I add a new node or other group of IPs, which need to have policies associated with them.
 
-- I dont want to look at 10 or 100 policies to figure out wether I have the right allow rules.
+- I dont want to look at 10 or 100 policies to figure out whether I have the right allow rules.
 
 - I wrote a policy, but am not sure if my policy did the right thing, nor if it has taken effect on the pods that I'm concerned with, yet.
 
@@ -31,22 +31,22 @@ other pods should be blocked from accessing it via any IP.
 
 - I want all namespaces matching X to be completely 100% locked-down by default; no pods can talk to any other pods until the developers specify policies allowing it - I may also want the converse situation for namespace Y.
 
-- I want to target all apps with network policies, but most of my apps need apiserver access, and i dont know the k8s service IP because all my clusters have different Service CIDRs.
+- I want to target all apps with network policies, but most of my apps need apiserver access, and i dont know the k8s service IP because all of my clusters have different Service CIDRs.
 
-- I want to block all pods from being able to reach ports on nodes. And the rule should automatically cover all nodes, and should cover all IPs on those nodes, except for port 53.
+- I want to block all pods from being able to reach ports on nodes. The rule should automatically cover all nodes, and all IPs on those nodes, except for port 53.
 
 ## tier-2
 
 - I want all namespaces to be “isolated” (don’t accept traffic from other Namespaces) by default; developers must specify if they want other namespaces to be able to access their services.
 
-- I want to administratively put a choke point between  pods that arent in the same app so i can audit cross-app dependencies and implement ingress controls by default in my cluster.
+- I want to administratively put a choke point between pods that arent in the same app so i can audit cross-app dependencies and implement ingress controls by default in my cluster.
 
 - I want to block all pods from being able to reach the AWS metadata server (169.254.169.254)
 except for pods in Namespace X, except I want to run kube2iam as a metadata proxy, so pods trying to access the metadata server should be redirected to that instead.
 
 - I want all pods to be blocked from accessing the internet.
 
-- I want all pods to be blocked from accessing the internet by default, but developers can add policies declaring what sites they need access to. Then those sites will be reachable, but if hackers break into the pod they can’t reach anywhere else besides those sites, except they can’t access 192.168.0.0/16 even if they declare it.
+- I want all pods to be blocked from accessing the internet by default, but developers can add policies declaring what sites they need access to. The sites will be reachable, but if hackers break into the pod they can’t reach anywhere else besides those sites, except they can’t access 192.168.0.0/16 even if they declare it.
 
 - I want pods in Namespace X to only have cluster egress via a proxy server provided by Service Y.
 


### PR DESCRIPTION
CLI tooling should be in scope for some specific user stories that may
be solved by small kubectl plugins for readbility or troubleshooting.
This PR also includes changes to whilespacing and grammar nits.

Signed-off-by: Christopher M. Luciano <cmluciano@us.ibm.com>