### PR TITLE
Update CIDR user-story to highlight usage of a slice

### DIFF
--- a/p0_user_stories.md
+++ b/p0_user_stories.md
@@ -21,7 +21,8 @@ Taken from https://docs.google.com/document/d/10t4q5XO1ED2PnK3ishn4y3G4Tma7uMYge
 
 ### v1 modifying
 
-- I don't want to directly update my CIDR rules for a policy every time I add a new node or other group of IPs, which need to have policies associated with them. 
+- I don't want to directly update my CIDR rules for a policy every time I add a new node or other group of IPs, which need to have policies associated with them.
+  - We can use a slice instead of a string for CIDR (KEP-able)
 
 - Writing network policies is hard, I forget what the defaults for ports, ingress/egress, and nil/empty collections (for label selectors and policy structs) are (see https://github.com/kubernetes/kubernetes/issues/51726 for official issue pointing to this).  This might result in revising or removing policy types.
 


### PR DESCRIPTION
Signed-off-by: Christopher M. Luciano <cmluciano@us.ibm.com>

Fixes: #10 

This clarifies an ask from the original gdoc WRT using a CIDR instead of a string.

@rikatz Please submit a PR with your suggestion from https://github.com/jayunit100/network-policy-subproject/pull/9/files#r475779353 if you're interested in trying out that idea