### PR TITLE
Update p0_user_stories.md

### DIFF
--- a/p0_user_stories.md
+++ b/p0_user_stories.md
@@ -133,3 +133,4 @@ As we move things via PRs, lets note the context so that we can detect cycles an
 - *Eric Bannon* strongly upvotes the need for "connect via namespace NAME" (seeing customers run into confusion here a lot) 
 - *David Byron* upvotes the "I want all namespaces matching X to be completely 100% locked-down by default" story.
 - *Ricardo* upvotes the "I want to allow my application to communicate with high level ports of another "legacy" application, which is not accessed via a service, and which binds to a random port or binds a a random port (like passive FTP)"
+- *Tim Downey* upvotes "I want 2 apps in different namespaces to connect via namespace NAME" **and** "I dont want to look at 10 or 100 policies to figure out whether I have the right allow rules"


### PR DESCRIPTION
Upvoting a couple stories.

_"I want 2 apps in different namespaces to connect via namespace NAME"_

I remember feeling surprised that this one wasn't possible out of the box and it's a pain in situations where you can't infer or update the labels on the namespace.

_"I dont want to look at 10 or 100 policies to figure out whether I have the right allow rules"_

This would be nice. 🙂 
Especially if you're working on an unfamiliar, shared cluster and aren't familiar with all the policies they've applied.